### PR TITLE
FIX: ipv6_with_prefixlen was not functional because of typo

### DIFF
--- a/templates/goshared/string.go
+++ b/templates/goshared/string.go
@@ -161,7 +161,7 @@ const strTpl = `
 			if !all { return err }
 			errors = append(errors, err)
 		}
-	{{ else if $r.GetIpv4WithPrefixlen }}
+	{{ else if $r.GetIpv6WithPrefixlen }}
 		if ip, _, err := net.ParseCIDR({{ accessor . }}); err != nil || ip.To6() == nil {
 			err := {{ err . "value must be a valid IPv6 address with prefixlen" }}
 			if !all { return err }


### PR DESCRIPTION
`$r.GetIpv6WithPrefixlen` を `$r.GetIpv4WithPrefixlen` と typo していて、
`ipv6_with_prefixlen` のバリデーションが機能していませんでした。
`feat/ip-and-prefix` ブランチに向けて修正します。:m_dogeza:

（まだ使われていなかったバリデーションなのでなんとかなっていた模様）